### PR TITLE
Fix: Remove --no-engine flag from Prisma generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate --no-engine",
+    "postinstall": "prisma generate",
     "sync-prod-data": "tsx scripts/sync-prod-data-enhanced.ts",
     "sync-prod-data:dry-run": "tsx scripts/sync-prod-data-enhanced.ts --dry-run",
     "sync-prod-data:original": "tsx scripts/sync-prod-data.ts"


### PR DESCRIPTION
## Summary

Fixes the Prisma error on main branch: "Error validating datasource `db`: the URL must start with the protocol `prisma://` or `prisma+postgres://`"

## Root Cause

The `--no-engine` flag in the postinstall script was preventing Prisma from generating local query engine binaries. This flag is only appropriate when exclusively using Prisma Accelerate, but the application supports both local PostgreSQL and Prisma Accelerate connections.

## Changes

- Removed `--no-engine` flag from `postinstall` script in package.json
- This allows Prisma to generate the necessary query engine binaries for local PostgreSQL connections

## Technical Details

The application already handles both connection types correctly in `/src/lib/prisma.ts`:
- For `prisma://` or `prisma+postgres://` URLs: Uses Prisma Accelerate extension
- For standard `postgresql://` URLs: Uses local query engine

The `--no-engine` flag was forcing Accelerate-only mode, breaking local development.

## Testing

- Confirmed dev server starts without Prisma errors
- Verified both `/` and `/library` pages load successfully
- Database queries execute properly with local PostgreSQL

## Impact

This is a **critical bug fix** for local development. The application now works correctly with:
- Local PostgreSQL databases (development)
- Prisma Accelerate (production)

Generated with [Claude Code](https://claude.com/claude-code)