### PR TITLE
feat: add social media links to profile page

### DIFF
--- a/prisma/migrations/20251125174723_add_social_media_links/migration.sql
+++ b/prisma/migrations/20251125174723_add_social_media_links/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "githubUrl" TEXT,
+ADD COLUMN     "instagramUrl" TEXT,
+ADD COLUMN     "letterboxdUrl" TEXT,
+ADD COLUMN     "linkedinUrl" TEXT,
+ADD COLUMN     "spotifyUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,13 @@ model User {
   // Format: https://[vercel-blob-url]/[user-id]/profile.[ext]
   profileImageUrl String? @db.Text
 
+  // Social media links
+  githubUrl     String? @db.Text
+  instagramUrl  String? @db.Text
+  linkedinUrl   String? @db.Text
+  letterboxdUrl String? @db.Text
+  spotifyUrl    String? @db.Text
+
   books        Book[]
   readingLists ReadingList[]
   createdAt    DateTime      @default(now())

--- a/src/app/components/home/EditProfileModal.tsx
+++ b/src/app/components/home/EditProfileModal.tsx
@@ -6,7 +6,7 @@ import { AlertCircle, Upload, Loader2, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import Modal from '@/components/ui/modal'
 import { Button } from '@/components/ui/button'
-import { uploadProfileImage, updateUserProfile } from '@/utils/actions/profile'
+import { uploadProfileImage, updateUserProfile, updateSocialMediaLinks } from '@/utils/actions/profile'
 import type { UserProfile } from '@/shared.types'
 
 interface EditProfileModalProps {
@@ -20,6 +20,11 @@ interface FormErrors {
   name?: string
   bio?: string
   image?: string
+  githubUrl?: string
+  instagramUrl?: string
+  linkedinUrl?: string
+  letterboxdUrl?: string
+  spotifyUrl?: string
   general?: string
 }
 
@@ -37,6 +42,11 @@ export function EditProfileModal({
   // Form state
   const [name, setName] = React.useState(profile.name || '')
   const [bio, setBio] = React.useState(profile.bio || '')
+  const [githubUrl, setGithubUrl] = React.useState(profile.githubUrl || '')
+  const [instagramUrl, setInstagramUrl] = React.useState(profile.instagramUrl || '')
+  const [linkedinUrl, setLinkedinUrl] = React.useState(profile.linkedinUrl || '')
+  const [letterboxdUrl, setLetterboxdUrl] = React.useState(profile.letterboxdUrl || '')
+  const [spotifyUrl, setSpotifyUrl] = React.useState(profile.spotifyUrl || '')
   const [imageFile, setImageFile] = React.useState<File | null>(null)
   const [imagePreview, setImagePreview] = React.useState<string | null>(null)
   const [removeImage, setRemoveImage] = React.useState(false)
@@ -53,6 +63,11 @@ export function EditProfileModal({
     if (isOpen) {
       setName(profile.name || '')
       setBio(profile.bio || '')
+      setGithubUrl(profile.githubUrl || '')
+      setInstagramUrl(profile.instagramUrl || '')
+      setLinkedinUrl(profile.linkedinUrl || '')
+      setLetterboxdUrl(profile.letterboxdUrl || '')
+      setSpotifyUrl(profile.spotifyUrl || '')
       setImageFile(null)
       setImagePreview(null)
       setRemoveImage(false)
@@ -196,7 +211,27 @@ export function EditProfileModal({
         // Currently disabled until bio field migration is run
       }
 
-      // 4. Handle image removal
+      // 4. Update social media links if changed
+      if (
+        githubUrl !== (profile.githubUrl || '') ||
+        instagramUrl !== (profile.instagramUrl || '') ||
+        linkedinUrl !== (profile.linkedinUrl || '') ||
+        letterboxdUrl !== (profile.letterboxdUrl || '') ||
+        spotifyUrl !== (profile.spotifyUrl || '')
+      ) {
+        const result = await updateSocialMediaLinks({
+          githubUrl,
+          instagramUrl,
+          linkedinUrl,
+          letterboxdUrl,
+          spotifyUrl,
+        })
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to update social media links')
+        }
+      }
+
+      // 5. Handle image removal
       if (removeImage && profile.profileImageUrl) {
         // TODO: Implement removeProfileImage server action if needed
         console.log('Remove profile image')
@@ -231,6 +266,11 @@ export function EditProfileModal({
   const hasChanges =
     name !== (profile.name || '') ||
     bio !== (profile.bio || '') ||
+    githubUrl !== (profile.githubUrl || '') ||
+    instagramUrl !== (profile.instagramUrl || '') ||
+    linkedinUrl !== (profile.linkedinUrl || '') ||
+    letterboxdUrl !== (profile.letterboxdUrl || '') ||
+    spotifyUrl !== (profile.spotifyUrl || '') ||
     imageFile !== null ||
     removeImage
 
@@ -484,10 +524,255 @@ export function EditProfileModal({
           </p>
         </div>
 
+        {/* Social Media Links Section */}
+        <div className="space-y-4 pt-4 border-t border-zinc-800">
+          <h3 className="text-sm font-medium text-zinc-300">Social Media</h3>
+
+          {/* GitHub URL */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="githubUrl"
+              className="text-sm font-medium text-zinc-400"
+            >
+              GitHub URL
+            </label>
+            <input
+              type="url"
+              id="githubUrl"
+              placeholder="https://github.com/username"
+              value={githubUrl}
+              onChange={(e) => {
+                setGithubUrl(e.target.value)
+                if (errors.githubUrl) {
+                  setErrors({ ...errors, githubUrl: undefined })
+                }
+              }}
+              disabled={isSubmitting}
+              aria-invalid={!!errors.githubUrl}
+              aria-describedby={errors.githubUrl ? 'github-error' : undefined}
+              inputMode="url"
+              autoComplete="url"
+              className={cn(
+                'px-3 py-2 bg-zinc-900 border rounded-lg',
+                'text-base sm:text-sm text-zinc-100',
+                'placeholder:text-zinc-600',
+                'focus:outline-none focus:ring-2 focus:border-transparent',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+                'transition-colors',
+                errors.githubUrl
+                  ? 'border-red-500 focus:ring-red-500'
+                  : 'border-zinc-800 focus:ring-zinc-600'
+              )}
+            />
+            {errors.githubUrl && (
+              <p
+                id="github-error"
+                className="text-xs text-red-400 flex items-center gap-1"
+                role="alert"
+              >
+                <AlertCircle className="h-3 w-3" />
+                {errors.githubUrl}
+              </p>
+            )}
+          </div>
+
+          {/* Instagram URL */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="instagramUrl"
+              className="text-sm font-medium text-zinc-400"
+            >
+              Instagram URL
+            </label>
+            <input
+              type="url"
+              id="instagramUrl"
+              placeholder="https://instagram.com/username"
+              value={instagramUrl}
+              onChange={(e) => {
+                setInstagramUrl(e.target.value)
+                if (errors.instagramUrl) {
+                  setErrors({ ...errors, instagramUrl: undefined })
+                }
+              }}
+              disabled={isSubmitting}
+              aria-invalid={!!errors.instagramUrl}
+              aria-describedby={errors.instagramUrl ? 'instagram-error' : undefined}
+              inputMode="url"
+              autoComplete="url"
+              className={cn(
+                'px-3 py-2 bg-zinc-900 border rounded-lg',
+                'text-base sm:text-sm text-zinc-100',
+                'placeholder:text-zinc-600',
+                'focus:outline-none focus:ring-2 focus:border-transparent',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+                'transition-colors',
+                errors.instagramUrl
+                  ? 'border-red-500 focus:ring-red-500'
+                  : 'border-zinc-800 focus:ring-zinc-600'
+              )}
+            />
+            {errors.instagramUrl && (
+              <p
+                id="instagram-error"
+                className="text-xs text-red-400 flex items-center gap-1"
+                role="alert"
+              >
+                <AlertCircle className="h-3 w-3" />
+                {errors.instagramUrl}
+              </p>
+            )}
+          </div>
+
+          {/* LinkedIn URL */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="linkedinUrl"
+              className="text-sm font-medium text-zinc-400"
+            >
+              LinkedIn URL
+            </label>
+            <input
+              type="url"
+              id="linkedinUrl"
+              placeholder="https://linkedin.com/in/username"
+              value={linkedinUrl}
+              onChange={(e) => {
+                setLinkedinUrl(e.target.value)
+                if (errors.linkedinUrl) {
+                  setErrors({ ...errors, linkedinUrl: undefined })
+                }
+              }}
+              disabled={isSubmitting}
+              aria-invalid={!!errors.linkedinUrl}
+              aria-describedby={errors.linkedinUrl ? 'linkedin-error' : undefined}
+              inputMode="url"
+              autoComplete="url"
+              className={cn(
+                'px-3 py-2 bg-zinc-900 border rounded-lg',
+                'text-base sm:text-sm text-zinc-100',
+                'placeholder:text-zinc-600',
+                'focus:outline-none focus:ring-2 focus:border-transparent',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+                'transition-colors',
+                errors.linkedinUrl
+                  ? 'border-red-500 focus:ring-red-500'
+                  : 'border-zinc-800 focus:ring-zinc-600'
+              )}
+            />
+            {errors.linkedinUrl && (
+              <p
+                id="linkedin-error"
+                className="text-xs text-red-400 flex items-center gap-1"
+                role="alert"
+              >
+                <AlertCircle className="h-3 w-3" />
+                {errors.linkedinUrl}
+              </p>
+            )}
+          </div>
+
+          {/* Letterboxd URL */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="letterboxdUrl"
+              className="text-sm font-medium text-zinc-400"
+            >
+              Letterboxd URL
+            </label>
+            <input
+              type="url"
+              id="letterboxdUrl"
+              placeholder="https://letterboxd.com/username"
+              value={letterboxdUrl}
+              onChange={(e) => {
+                setLetterboxdUrl(e.target.value)
+                if (errors.letterboxdUrl) {
+                  setErrors({ ...errors, letterboxdUrl: undefined })
+                }
+              }}
+              disabled={isSubmitting}
+              aria-invalid={!!errors.letterboxdUrl}
+              aria-describedby={errors.letterboxdUrl ? 'letterboxd-error' : undefined}
+              inputMode="url"
+              autoComplete="url"
+              className={cn(
+                'px-3 py-2 bg-zinc-900 border rounded-lg',
+                'text-base sm:text-sm text-zinc-100',
+                'placeholder:text-zinc-600',
+                'focus:outline-none focus:ring-2 focus:border-transparent',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+                'transition-colors',
+                errors.letterboxdUrl
+                  ? 'border-red-500 focus:ring-red-500'
+                  : 'border-zinc-800 focus:ring-zinc-600'
+              )}
+            />
+            {errors.letterboxdUrl && (
+              <p
+                id="letterboxd-error"
+                className="text-xs text-red-400 flex items-center gap-1"
+                role="alert"
+              >
+                <AlertCircle className="h-3 w-3" />
+                {errors.letterboxdUrl}
+              </p>
+            )}
+          </div>
+
+          {/* Spotify URL */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="spotifyUrl"
+              className="text-sm font-medium text-zinc-400"
+            >
+              Spotify URL
+            </label>
+            <input
+              type="url"
+              id="spotifyUrl"
+              placeholder="https://open.spotify.com/user/username"
+              value={spotifyUrl}
+              onChange={(e) => {
+                setSpotifyUrl(e.target.value)
+                if (errors.spotifyUrl) {
+                  setErrors({ ...errors, spotifyUrl: undefined })
+                }
+              }}
+              disabled={isSubmitting}
+              aria-invalid={!!errors.spotifyUrl}
+              aria-describedby={errors.spotifyUrl ? 'spotify-error' : undefined}
+              inputMode="url"
+              autoComplete="url"
+              className={cn(
+                'px-3 py-2 bg-zinc-900 border rounded-lg',
+                'text-base sm:text-sm text-zinc-100',
+                'placeholder:text-zinc-600',
+                'focus:outline-none focus:ring-2 focus:border-transparent',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+                'transition-colors',
+                errors.spotifyUrl
+                  ? 'border-red-500 focus:ring-red-500'
+                  : 'border-zinc-800 focus:ring-zinc-600'
+              )}
+            />
+            {errors.spotifyUrl && (
+              <p
+                id="spotify-error"
+                className="text-xs text-red-400 flex items-center gap-1"
+                role="alert"
+              >
+                <AlertCircle className="h-3 w-3" />
+                {errors.spotifyUrl}
+              </p>
+            )}
+          </div>
+        </div>
+
         {/* Note about bio field */}
         <div className="p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
           <p className="text-xs text-blue-300">
-            Note: Bio updates will be available after the database migration is complete.
+            Note: Bio and social media updates will be available after the database migration is complete.
           </p>
         </div>
 

--- a/src/app/components/home/ProfileBio.tsx
+++ b/src/app/components/home/ProfileBio.tsx
@@ -6,6 +6,7 @@ import { User, Pencil } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { EditProfileModal } from './EditProfileModal'
+import { SocialMediaLinks } from './SocialMediaLinks'
 import type { UserProfile } from '@/shared.types'
 
 export interface ProfileBioProps {
@@ -97,13 +98,16 @@ const ProfileBio = React.forwardRef<HTMLDivElement, ProfileBioProps>(
         </div>
 
         {/* User Info */}
-        <div className="flex flex-col items-center gap-2 text-center max-w-2xl px-4">
+        <div className="flex flex-col items-center gap-3 text-center max-w-2xl px-4">
           {/* Name */}
           {profile.name && (
             <h1 className="text-2xl md:text-3xl font-semibold text-zinc-100">
               {profile.name}
             </h1>
           )}
+
+          {/* Social Media Links */}
+          <SocialMediaLinks profile={profile} />
 
           {/* Bio */}
           {profile.bio && (

--- a/src/app/components/home/SocialMediaLinks.tsx
+++ b/src/app/components/home/SocialMediaLinks.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import * as React from 'react'
+import { Github, Instagram, Linkedin } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { UserProfile } from '@/shared.types'
+
+// Custom Letterboxd icon - three overlapping dots with brand colors
+const LetterboxdIcon = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    className={className}
+    aria-hidden="true"
+  >
+    <circle cx="5" cy="12" r="4" fill="#00E054" />
+    <circle cx="12" cy="12" r="4" fill="#40BCF4" />
+    <circle cx="19" cy="12" r="4" fill="#FF8000" />
+  </svg>
+)
+
+// Custom Spotify icon (official logo)
+const SpotifyIcon = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+    aria-hidden="true"
+  >
+    <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+  </svg>
+)
+
+export interface SocialMediaLinksProps {
+  profile: UserProfile
+  className?: string
+}
+
+interface SocialLink {
+  url: string
+  icon: React.ReactNode
+  label: string
+  platform: string
+  colorClass: string
+}
+
+const SocialMediaLinks = React.forwardRef<HTMLDivElement, SocialMediaLinksProps>(
+  ({ profile, className }, ref) => {
+    // Build array of social links from profile
+    const socialLinks: SocialLink[] = React.useMemo(() => {
+      const links: SocialLink[] = []
+
+      if (profile.githubUrl) {
+        links.push({
+          url: profile.githubUrl,
+          icon: <Github className="w-5 h-5" />,
+          label: 'GitHub',
+          platform: 'github',
+          colorClass: 'text-zinc-400 hover:text-white',
+        })
+      }
+
+      if (profile.instagramUrl) {
+        links.push({
+          url: profile.instagramUrl,
+          icon: <Instagram className="w-5 h-5" />,
+          label: 'Instagram',
+          platform: 'instagram',
+          colorClass: 'text-pink-400/70 hover:text-pink-400',
+        })
+      }
+
+      if (profile.linkedinUrl) {
+        links.push({
+          url: profile.linkedinUrl,
+          icon: <Linkedin className="w-5 h-5" />,
+          label: 'LinkedIn',
+          platform: 'linkedin',
+          colorClass: 'text-blue-400/70 hover:text-blue-400',
+        })
+      }
+
+      if (profile.letterboxdUrl) {
+        links.push({
+          url: profile.letterboxdUrl,
+          icon: <LetterboxdIcon className="w-5 h-5" />,
+          label: 'Letterboxd',
+          platform: 'letterboxd',
+          colorClass: 'opacity-70 hover:opacity-100',
+        })
+      }
+
+      if (profile.spotifyUrl) {
+        links.push({
+          url: profile.spotifyUrl,
+          icon: <SpotifyIcon className="w-5 h-5" />,
+          label: 'Spotify',
+          platform: 'spotify',
+          colorClass: 'text-green-400/70 hover:text-green-400',
+        })
+      }
+
+      return links
+    }, [profile])
+
+    // Don't render if no social links
+    if (socialLinks.length === 0) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn('flex items-center justify-center gap-4', className)}
+        role="list"
+        aria-label="Social media links"
+      >
+        {socialLinks.map((link) => (
+          <a
+            key={link.platform}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              'group relative flex items-center justify-center',
+              'transition-all duration-200 ease-out',
+              'hover:scale-110',
+              'focus-visible:outline-none',
+              'active:scale-95',
+              link.colorClass
+            )}
+            aria-label={`Visit ${link.label} profile`}
+            role="listitem"
+          >
+            {link.icon}
+
+            {/* Tooltip on hover */}
+            <span
+              className={cn(
+                'absolute -bottom-7 left-1/2 -translate-x-1/2',
+                'px-2 py-0.5 rounded text-xs',
+                'text-white/60',
+                'whitespace-nowrap',
+                'opacity-0 group-hover:opacity-100',
+                'transition-opacity duration-200',
+                'pointer-events-none'
+              )}
+              role="tooltip"
+            >
+              {link.label}
+            </span>
+          </a>
+        ))}
+      </div>
+    )
+  }
+)
+
+SocialMediaLinks.displayName = 'SocialMediaLinks'
+
+export { SocialMediaLinks }

--- a/src/app/components/home/index.ts
+++ b/src/app/components/home/index.ts
@@ -1,5 +1,6 @@
 // Home screen components
 export { ProfileBio } from './ProfileBio'
+export { SocialMediaLinks } from './SocialMediaLinks'
 export { FavoriteBooksSection } from './FavoriteBooksSection'
 export { FavoriteBooksHeader } from './FavoriteBooksHeader'
 export { FavoriteBooksCarousel } from './FavoriteBooksCarousel'

--- a/src/shared.types.ts
+++ b/src/shared.types.ts
@@ -120,6 +120,11 @@ export interface UserProfile {
   email: string;
   profileImageUrl?: string | null;
   bio?: string | null; // Future field for user biography
+  githubUrl?: string | null;
+  instagramUrl?: string | null;
+  linkedinUrl?: string | null;
+  letterboxdUrl?: string | null;
+  spotifyUrl?: string | null;
 }
 
 export type { BookType, BookImportDataType, SearchSuggestion };


### PR DESCRIPTION
## Summary
- Add elegant social media links (GitHub, Instagram, LinkedIn, Letterboxd, Spotify) under user's name on profile page
- Minimal, borderless icons with subtle brand colors and hover effects
- Custom SVG icons for Letterboxd (official three-dot logo with brand colors) and Spotify
- Edit social links via the Edit Profile modal with URL validation

## Test plan
- [ ] Log in and navigate to profile page
- [ ] Open Edit Profile modal and add social media URLs
- [ ] Verify links save correctly and display under name
- [ ] Check hover effects brighten icons appropriately
- [ ] Verify links open in new tabs
- [ ] Run database migration on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)