### PR TITLE
feat: admin settings page for default user configuration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,3 +163,20 @@ model BookInReadingList {
   @@index([readingListId, position]) // For fetching books in order
   @@index([bookId]) // For finding all lists containing a book
 }
+
+// App-wide settings stored in database (singleton pattern)
+// This allows admins to configure app behavior without env variable changes
+model AppSettings {
+  id Int @id @default(1) // Always ID 1 (singleton)
+
+  // Default user profile to show on home page for unauthenticated visitors
+  // References User.clerkId (not internal id) for consistency with auth system
+  defaultUserClerkId String?
+
+  // Future settings can be added here:
+  // siteName String?
+  // siteDescription String?
+  // maintenanceMode Boolean @default(false)
+
+  updatedAt DateTime @updatedAt
+}

--- a/src/app/admin/settings/components/AdminSettingsForm.tsx
+++ b/src/app/admin/settings/components/AdminSettingsForm.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import { updateDefaultUser } from "@/utils/actions/admin-settings";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Check, Loader2 } from "lucide-react";
+import Image from "next/image";
+
+interface User {
+  id: number;
+  clerkId: string;
+  name: string | null;
+  email: string;
+  profileImageUrl: string | null;
+}
+
+interface AdminSettingsFormProps {
+  users: User[];
+  currentDefaultUserClerkId: string | null;
+}
+
+export function AdminSettingsForm({
+  users,
+  currentDefaultUserClerkId,
+}: AdminSettingsFormProps) {
+  const [selectedClerkId, setSelectedClerkId] = React.useState<string | null>(
+    currentDefaultUserClerkId
+  );
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [successMessage, setSuccessMessage] = React.useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const hasChanges = selectedClerkId !== currentDefaultUserClerkId;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setSuccessMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const result = await updateDefaultUser(selectedClerkId);
+
+      if (result.success) {
+        setSuccessMessage("Default user updated successfully");
+        // Clear after 3 seconds
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } else {
+        setErrorMessage(result.error || "Failed to update settings");
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "An error occurred"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Default User Selection */}
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-zinc-300">
+          Default User Profile
+        </label>
+        <p className="text-sm text-zinc-500">
+          Select which user&apos;s profile to display on the home page for
+          unauthenticated visitors.
+        </p>
+
+        <select
+          value={selectedClerkId || ""}
+          onChange={(e) => setSelectedClerkId(e.target.value || null)}
+          className={cn(
+            "w-full h-10 rounded-md border border-zinc-700",
+            "bg-zinc-900 px-3 py-2 text-sm text-zinc-100",
+            "focus:outline-none focus:ring-2 focus:ring-zinc-500",
+            "disabled:cursor-not-allowed disabled:opacity-50"
+          )}
+          disabled={isSubmitting}
+        >
+          <option value="">-- No default user (guest view) --</option>
+          {users.map((user) => (
+            <option key={user.clerkId} value={user.clerkId}>
+              {user.name || user.email} ({user.email})
+            </option>
+          ))}
+        </select>
+
+        {/* Selected user preview */}
+        {selectedClerkId && (
+          <SelectedUserPreview
+            user={users.find((u) => u.clerkId === selectedClerkId) || null}
+          />
+        )}
+      </div>
+
+      {/* Status Messages */}
+      {successMessage && (
+        <div className="flex items-center gap-2 text-green-400 text-sm">
+          <Check className="w-4 h-4" />
+          {successMessage}
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className="text-red-400 text-sm">{errorMessage}</div>
+      )}
+
+      {/* Submit Button */}
+      <div className="flex gap-3">
+        <Button
+          type="submit"
+          disabled={!hasChanges || isSubmitting}
+          className="bg-zinc-700 hover:bg-zinc-600"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            "Save Changes"
+          )}
+        </Button>
+
+        {hasChanges && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setSelectedClerkId(currentDefaultUserClerkId)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function SelectedUserPreview({ user }: { user: User | null }) {
+  if (!user) return null;
+
+  const firstLetter = user.name
+    ? user.name.charAt(0).toUpperCase()
+    : user.email.charAt(0).toUpperCase();
+
+  return (
+    <div className="mt-3 p-4 rounded-lg bg-zinc-800/50 border border-zinc-700">
+      <div className="flex items-center gap-3">
+        {/* Avatar */}
+        <div className="relative w-12 h-12 rounded-full overflow-hidden bg-zinc-700 flex-shrink-0">
+          {user.profileImageUrl ? (
+            <Image
+              src={user.profileImageUrl}
+              alt={user.name || user.email}
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-zinc-600">
+              <span className="text-lg font-bold text-zinc-100">
+                {firstLetter}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-zinc-100 truncate">
+            {user.name || "No name set"}
+          </p>
+          <p className="text-sm text-zinc-400 truncate">{user.email}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+import {
+  isAdmin,
+  getAllUsersForAdmin,
+  getAppSettings,
+} from "@/utils/actions/admin-settings";
+import { AdminSettingsForm } from "./components/AdminSettingsForm";
+
+export default async function AdminSettingsPage() {
+  // Check admin access - redirect if not admin
+  const admin = await isAdmin();
+  if (!admin) {
+    redirect("/");
+  }
+
+  // Fetch data in parallel
+  const [usersResult, settingsResult] = await Promise.all([
+    getAllUsersForAdmin(),
+    getAppSettings(),
+  ]);
+
+  if (!usersResult.success || !settingsResult.success) {
+    return (
+      <div className="w-full max-w-2xl mx-auto p-6">
+        <h1 className="text-3xl font-semibold mb-6 text-zinc-100">
+          Admin Settings
+        </h1>
+        <div className="text-red-400">
+          Error loading settings: {usersResult.error || settingsResult.error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-2xl mx-auto p-6">
+      <h1 className="text-3xl font-semibold mb-6 text-zinc-100">
+        Admin Settings
+      </h1>
+
+      <AdminSettingsForm
+        users={usersResult.users}
+        currentDefaultUserClerkId={settingsResult.settings?.defaultUserClerkId || null}
+      />
+    </div>
+  );
+}

--- a/src/utils/actions/admin-settings.ts
+++ b/src/utils/actions/admin-settings.ts
@@ -1,0 +1,174 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import prisma from "@/lib/prisma";
+
+// Admin Clerk ID - only this user can access admin settings
+const ADMIN_CLERK_ID = process.env.ADMIN_CLERK_ID;
+
+/**
+ * Check if the current user is an admin
+ * @returns boolean indicating if user is admin
+ */
+export async function isAdmin(): Promise<boolean> {
+  try {
+    const { userId: clerkId } = await auth();
+    if (!clerkId || !ADMIN_CLERK_ID) {
+      return false;
+    }
+    return clerkId === ADMIN_CLERK_ID;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Require admin access - throws error if not admin
+ * Use this at the start of any admin-only action
+ */
+async function requireAdmin(): Promise<void> {
+  const admin = await isAdmin();
+  if (!admin) {
+    throw new Error("Unauthorized: Admin access required");
+  }
+}
+
+/**
+ * Get all users for the admin dropdown
+ * @returns List of users with id, clerkId, name, and email
+ */
+export async function getAllUsersForAdmin() {
+  await requireAdmin();
+
+  try {
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        clerkId: true,
+        name: true,
+        email: true,
+        profileImageUrl: true,
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
+
+    return {
+      success: true,
+      users,
+    };
+  } catch (error) {
+    console.error("Get all users error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to fetch users",
+      users: [],
+    };
+  }
+}
+
+/**
+ * Get the current app settings
+ * @returns Current AppSettings record
+ */
+export async function getAppSettings() {
+  await requireAdmin();
+
+  try {
+    // Get or create the singleton settings record
+    let settings = await prisma.appSettings.findUnique({
+      where: { id: 1 },
+    });
+
+    // If no settings exist, create the singleton record
+    if (!settings) {
+      settings = await prisma.appSettings.create({
+        data: {
+          id: 1,
+          defaultUserClerkId: null,
+        },
+      });
+    }
+
+    return {
+      success: true,
+      settings,
+    };
+  } catch (error) {
+    console.error("Get app settings error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to fetch settings",
+      settings: null,
+    };
+  }
+}
+
+/**
+ * Update the default user for the home page
+ * @param clerkId - The Clerk ID of the user to set as default (or null to clear)
+ * @returns Success status
+ */
+export async function updateDefaultUser(clerkId: string | null) {
+  await requireAdmin();
+
+  try {
+    // Validate that the user exists if a clerkId is provided
+    if (clerkId) {
+      const userExists = await prisma.user.findUnique({
+        where: { clerkId },
+        select: { id: true },
+      });
+
+      if (!userExists) {
+        return {
+          success: false,
+          error: "Selected user does not exist",
+        };
+      }
+    }
+
+    // Upsert the settings record
+    await prisma.appSettings.upsert({
+      where: { id: 1 },
+      update: {
+        defaultUserClerkId: clerkId,
+      },
+      create: {
+        id: 1,
+        defaultUserClerkId: clerkId,
+      },
+    });
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    console.error("Update default user error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update settings",
+    };
+  }
+}
+
+/**
+ * Get the default user Clerk ID from app settings
+ * This is used by home-page.ts to determine which profile to show
+ * Does NOT require admin access - this is a public read
+ * @returns The default user's Clerk ID or null if not configured
+ */
+export async function getDefaultUserClerkId(): Promise<string | null> {
+  try {
+    const settings = await prisma.appSettings.findUnique({
+      where: { id: 1 },
+      select: { defaultUserClerkId: true },
+    });
+
+    return settings?.defaultUserClerkId || null;
+  } catch (error) {
+    console.error("Get default user clerk ID error:", error);
+    return null;
+  }
+}

--- a/src/utils/actions/home-page.ts
+++ b/src/utils/actions/home-page.ts
@@ -3,6 +3,7 @@
 import { auth } from "@clerk/nextjs/server";
 import prisma from "@/lib/prisma";
 import type { UserProfile, ReadingListWithBooks } from "@/shared.types";
+import { getDefaultUserClerkId } from "./admin-settings";
 
 // Define clear result types
 export type HomePageStatus =
@@ -52,14 +53,14 @@ export async function getHomePageData(): Promise<HomePageResult> {
       targetClerkId = clerkId;
       isOwner = true;
     } else {
-      // Not authenticated: check for default user
-      const defaultUserId = process.env.DEFAULT_USER_ID?.trim();
+      // Not authenticated: get default user from database
+      const defaultUserId = await getDefaultUserClerkId();
 
       if (!defaultUserId) {
-        // No default user configured - return error state
+        // No default user configured - return guest view state
         return {
           status: "not_configured",
-          error: "DEFAULT_USER_ID environment variable is not configured",
+          error: "No default user configured in admin settings",
           profile: null,
           readingLists: [],
           permissions: {


### PR DESCRIPTION
## Summary
- Add admin settings page at `/admin/settings` for configuring the default user profile
- Replace environment variable `DEFAULT_USER_ID` with database-stored configuration
- Only accessible to admin (controlled via `ADMIN_CLERK_ID` env variable)

## Changes
- **Prisma Schema:** Add `AppSettings` model (singleton pattern) to store app configuration
- **Server Actions:** Create `admin-settings.ts` with admin-only actions
- **Admin Page:** Create `/admin/settings` with user dropdown selector and preview
- **Home Page:** Update `home-page.ts` to fetch default user from database instead of env variable

## Setup Required After Merge

1. **Run database migration:**
   ```bash
   npx prisma migrate deploy
   ```

2. **Set ADMIN_CLERK_ID in Vercel:**
   - Go to Vercel project settings > Environment Variables
   - Add `ADMIN_CLERK_ID` with your Clerk user ID (get it from Clerk dashboard)

3. **Configure default user:**
   - Navigate to `/admin/settings` when logged in as admin
   - Select the user whose profile should be shown to unauthenticated visitors

## Test plan
- [ ] Admin can access `/admin/settings` when ADMIN_CLERK_ID matches
- [ ] Non-admin users are redirected from `/admin/settings`
- [ ] Dropdown lists all users with name and email
- [ ] Selected user preview shows avatar and info
- [ ] Saving updates the database correctly
- [ ] Home page shows selected user's profile for unauthenticated visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)