### PR TITLE
fix: resolve infinite loading state on library cover images

### DIFF
--- a/src/app/library/components/gridItem.tsx
+++ b/src/app/library/components/gridItem.tsx
@@ -1,6 +1,7 @@
 import { Dispatch, FC, SetStateAction, useState, useEffect } from "react";
 import { BookType } from "@/shared.types";
 import { ImageIcon, BookOpen } from "lucide-react";
+import Image from "next/image";
 
 type GridItemProps = {
   book: BookType;
@@ -57,17 +58,19 @@ const GridItem: FC<GridItemProps> = ({ book, setSelectedBook, isSelected = false
             )}
 
             {/* Book Cover Image */}
-            <img
+            <Image
               src={image}
               alt={`Cover of ${title}`}
-              onLoad={() => {
+              fill
+              sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+              onLoadingComplete={() => {
                 setImageLoading(false);
               }}
               onError={() => {
                 setImageLoading(false);
                 setImageError(true);
               }}
-              className={`w-full h-full object-cover transition-all duration-300 ${
+              className={`object-cover transition-all duration-300 ${
                 imageLoading ? 'opacity-0' : 'opacity-100'
               } ${showOverlay ? 'scale-105' : 'scale-100'}`}
             />

--- a/src/app/library/components/item.tsx
+++ b/src/app/library/components/item.tsx
@@ -1,6 +1,7 @@
 import { Dispatch, FC, SetStateAction, useState, useEffect } from "react";
 import { BookType } from "@/shared.types";
 import { ImageIcon } from "lucide-react";
+import Image from "next/image";
 
 type ItemProps = {
   book: BookType;
@@ -59,14 +60,16 @@ const Item: FC<ItemProps> = ({ book, setSelectedBook, isSelected = false }) => {
         {/* Book Cover */}
         <div className="flex items-center justify-center min-w-[70px] sm:min-w-[120px]">
           {image && !imageError ? (
-            <div className="relative w-[60px] sm:w-[100px]">
+            <div className="relative w-[60px] h-[90px] sm:w-[100px] sm:h-[160px]">
               {imageLoading && (
-                <div className="absolute inset-0 bg-zinc-800 animate-pulse rounded w-[60px] h-[90px] sm:w-[100px] sm:h-[160px]" />
+                <div className="absolute inset-0 bg-zinc-800 animate-pulse rounded" />
               )}
-              <img
+              <Image
                 src={image}
                 alt={`Cover of ${title}`}
-                onLoad={() => {
+                width={100}
+                height={160}
+                onLoadingComplete={() => {
                   if (image) {
                     imageCache.set(image, true);
                   }
@@ -76,7 +79,7 @@ const Item: FC<ItemProps> = ({ book, setSelectedBook, isSelected = false }) => {
                   setImageLoading(false);
                   setImageError(true);
                 }}
-                className={`max-h-[90px] sm:max-h-[160px] object-fill transition-opacity duration-300 rounded shadow-md ${
+                className={`max-h-[90px] sm:max-h-[160px] w-auto object-contain transition-opacity duration-300 rounded shadow-md ${
                   imageLoading ? 'opacity-0' : 'opacity-100'
                 }`}
               />


### PR DESCRIPTION
## Summary
- Fixed infinite loading skeleton on cover images in library view
- Replaced native `<img>` with Next.js `<Image>` component
- Changed `onLoad` to `onLoadingComplete` to handle cached images reliably

## Problem
When browsing the library in production, cover images would show infinite loading animation (pulse skeleton) until a book was selected or view changed. This occurred because the native `onLoad` event fires before React attaches the handler when images are browser-cached.

## Solution
Next.js `onLoadingComplete` callback reliably fires even for cached images by checking load state synchronously after mount.

## Test plan
- [ ] Browse library in production - images should load without getting stuck
- [ ] Verify cached images (on page revisit) load immediately without stuck skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)